### PR TITLE
Make the Prolog code less SWI-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 a.out
+csv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,35 @@
 # wordnet-prolog utilities (c) 2017-20 Eric Kafe
 # License: CC BY 4.0, https://creativecommons.org/licenses/by/4.0/
 
+# 2025-12: extended for others Prolog systems (swi, gprolog, tpl)
+# For gprolog set:
+# export LOCALSZ=200000
+# export TRAILSZ=100000
+# export GLOBALSZ=700000
+# export MAX_ATOM=500000
+
+
+PL ?= swi
+
+# --- fonctions to run Prolog on given file and halt ---
+define run_swi
+swipl -g 'halt' $(1)
+endef
+
+define run_gprolog
+gprolog --init-goal "consult('$(1)'), halt"
+endef
+
+define run_tpl
+tpl -g 'halt' $(1)
+endef
+
+
+# Add others Prolog system here
+
+# -----------------------------------------------------
+
+
 all: doc valid query csv
 
 # Groff is required for building the documentation
@@ -19,25 +48,25 @@ ps:
 	@groff -mandoc -Tps doc/prologdb.5>doc/prologdb.ps
 
 query:
-	@echo Testing example queries...
-	swipl -c wn_query.pl
+	@echo "Testing example queries with $(PL)..."
+	@$(call run_$(PL),wn_query.pl)
 
 valid:
-	@echo Checking symmetry and asymmetry ...
-	swipl -c wn_valid.pl
+	@echo "Checking symmetry and asymmetry with $(PL)..."
+	@$(call run_$(PL),wn_valid.pl)
 
 csv:
 	@mkdir csv
-	@echo Converting Prolog databases to CSV
-	swipl -c wn2csv.pl
+	@echo "Converting Prolog databases to CSV with $(PL)..."
+	@$(call run_$(PL),wn2csv.pl)
 
 cleanpl:
 	@echo Deleting Prolog output
-	@rm a.out
-#	@rm output/wn*Output*
+	@rm -rf a.out
+#	@rm -rf output/wn*Output*
 
 cleancsv:
 	@echo Deleting CSV files
-	@rm -r csv
+	@rm -rf csv
 
 clean: cleanpl cleancsv

--- a/README.md
+++ b/README.md
@@ -79,3 +79,31 @@ CSV versions of the WordNet databases (output by _wn2csv.pl_) are now
 available through the _wncsv_ project at:
 
 https://github.com/ekaf/wncsv
+
+## News (2025):
+
+The programs have been made less specific to SWI by Daniel Diaz. 
+To achieve this, we have favored ISO Prolog and commonly supported extensions
+(such as format/2). The corresponding git commit includes a detailed description 
+of the changes.  
+
+The Makefile design has been revised so that the desired Prolog can be passed as
+a parameter with: 
+
+make <target> PL=<system>
+
+Currently, in addition to SWI Prolog (swi), GNU Prolog (gprolog) or Trealla
+Prolog (tpl) can also be used. It should be easy to add support for other
+systems (see wn_compat.pl for system-specific definitions).
+
+For gprolog, the following environment variables must be defined:
+
+export LOCALSZ=200000
+export TRAILSZ=100000
+export GLOBALSZ=700000
+export MAX_ATOM=500000
+
+Then to run valid:
+
+make valid PL=gprolog
+

--- a/output/wn_valid.pl-Output-3.1
+++ b/output/wn_valid.pl-Output-3.1
@@ -118,10 +118,7 @@ OK
 Morphological Info: [exc]
 Checking duplicates in exc/3
 Found 3 duplicate exc:
-:- dynamic duplicate/3.
-
-duplicate(2, exc, [n, diastemata, diastema]).
-duplicate(2, exc, [n, sudatoria, sudatorium]).
-duplicate(2, exc, [n, vagi, vagus]).
-
+duplicate(2, exc, [n,diastemata,diastema]).
+duplicate(2, exc, [n,sudatoria,sudatorium]).
+duplicate(2, exc, [n,vagi,vagus]).
 

--- a/wn2csv.pl
+++ b/wn2csv.pl
@@ -5,25 +5,24 @@
 SWI-prolog program to convert all WordNet databases to comma-separated CSV files
 */
 
-:-consult('wn_load.pl').
+:- include(wn_compat).
+:- include(wn_load).
 
 pred2file(P):-
   atom_concat('csv/wn_',P,C1),
   atom_concat(C1,'.csv',C),
-  writef('Writing  %w\n',[C]),
+  format('Writing  ~w\n',[C]),
   tell(C).
 
-list2csv([A],S0,S2):-
-  swritef(S2,'%w%q',[S0,A]).
-list2csv([A,B|T],S0,S2):-
-  swritef(S1,'%w%q,',[S0,A]),
-  list2csv([B|T],S1,S2).
+list2csv([],_).
+list2csv([A|T],S):-
+  format('~a~q',[S,A]),
+  list2csv(T,',').
 
 out2csv(P):-
   pred2arity(P,_,L),
   apply(P,L),
-  list2csv(L,'',S),
-  writeln(S),
+  list2csv(L,''), nl,
   false.
 out2csv(_):-
   told.
@@ -37,4 +36,4 @@ convert_wn:-
 convert_wn:-
   nl.
 
-:-convert_wn.
+:- initialization(convert_wn).

--- a/wn_compat.pl
+++ b/wn_compat.pl
@@ -1,0 +1,34 @@
+/* 
+https://github.com/ekaf/wordnet-prolog/raw/master/wn_compat.pl
+(c) 2017-20 Eric Kafe, CC BY 4.0, https://creativecommons.org/licenses/by/4.0/
+
+Prolog system-dependent features
+*/
+
+
+% provisional since scryer prolog does not provide the dialect flag nor if/1 directive
+
+:- if(current_prolog_flag(dialect, scryer)).
+
+:- use_module(library(format)).
+:- use_module(library(lists)).
+
+:-endif.
+
+
+
+:- if(\+predicate_property(list_to_set(_,_),_)).
+
+list_to_set(Ls0, Ls) :-
+  sort(Ls0, Ls).
+
+:- endif.
+
+
+:- if(\+predicate_property(apply(_,_),_)).
+
+apply(P, L) :-
+  G =.. [P|L],
+  call(G).
+
+:- endif.

--- a/wn_load.pl
+++ b/wn_load.pl
@@ -13,34 +13,36 @@ morphinfo(['exc']).
 
 allwn(L):-
   semrels(L),
-  writef('\nSemantic Relations: %w\n', [L]).
+  format('\nSemantic Relations: ~w\n', [L]).
 allwn(L):-
   lexrels(L),
-  writef('\nLexical Relations: %w\n', [L]).
+  format('\nLexical Relations: ~w\n', [L]).
 allwn(L):-
   lexinfo(L),
-  writef('\nLexical Info: %w\n', [L]).
+  format('\nLexical Info: ~w\n', [L]).
 allwn(L):-
   seminfo(L),
-  writef('\nSemantic Info: %w\n', [L]).
+  format('\nSemantic Info: ~w\n', [L]).
 allwn(L):-
   morphinfo(L),
-  writef('\nMorphological Info: %w\n', [L]).
+  format('\nMorphological Info: ~w\n', [L]).
 
 /* ------------------------------------------
 Load WN
 ------------------------------------------ */
 
+pred2arity(P,A):-
+  current_predicate(P/A), !.	% should be deterministic !
+
 pred2arity(P,A,L):-
-  current_predicate(P,Term),
-  Term =.. [P|L],
+  pred2arity(P,A),
   length(L,A).
 
 loadpred(P):-
-  swritef(F,'prolog/wn_%w.pl',[P]),
-  consult(F),
+  atom_concat('prolog/wn_', P, F),
+  loadfile(F),
   pred2arity(P,A,_),
-  writef('Loaded %w (%w/%w)\n',[F,P,A]).
+  format('Loaded ~w.pl (~w/~w)\n',[F,P,A]).
 
 loadwn:-
   allwn(L),
@@ -50,4 +52,29 @@ loadwn:-
 loadwn:-
   nl.
 
-:-loadwn.
+:- if((current_predicate(use_term_expansion/0), current_prolog_flag(dialect, D), D \== swi)).
+:- if(current_prolog_flag(dialect, gprolog)).
+
+loadfile(F) :-
+  decompose_file_name(F,_,wn_sk,_), !,
+  consult(F, [include(wn_term_expans)]).
+
+loadfile(F) :-
+  consult(F).
+
+:- else.
+
+:- include(wn_term_expans).
+
+loadfile(F) :-
+  consult(F).
+
+:- endif.
+
+:- else.
+
+loadfile(F) :-
+  consult(F).
+
+:- endif.
+

--- a/wn_morphy.pl
+++ b/wn_morphy.pl
@@ -7,8 +7,9 @@ the morphological processor from WordNet.
 
 -------------------------------------------------------------------------------*/
 
-:-consult(prolog/wn_exc).
-:-consult(prolog/wn_s).
+:- include(wn_compat).
+:- include('prolog/wn_exc').
+:- include('prolog/wn_s').
 
 % Since v. 7.0, swipl requires this flag for double quotes to produce bytelists:
 :-set_prolog_flag(double_quotes,codes).
@@ -64,4 +65,7 @@ morphy(Wordform, Set):-
     Set).
 
 % Example usage:
-%:-morphy(advertizing, S), writeln(S).
+%go:-morphy(advertizing, S), write(S), nl.
+% :- initialization(go).
+
+

--- a/wn_query.pl
+++ b/wn_query.pl
@@ -6,22 +6,22 @@ SWI-prolog program implementing some common WordNet use cases,
 and a few formal checks, like symmetry and transitive loop detection.
 */
 
-:-consult('db_version.pl').
-:-consult('prolog/wn_s.pl').
+:- include(wn_compat).
+:- include(db_version). 
+:- include('prolog/wn_s.pl').
 
 semrels(['at','cs','ent','hyp','ins','mm','mp','ms','sim']).
 
 loadrels:-
   semrels(L),
   member(R,L),
-  swritef(F,'prolog/wn_%w.pl',[R]),
-  writef('Consulting %w relation: %w\n',[R,F]),
-  consult(F),
+  atom_concat('prolog/wn_',R,F),
+  format('Consulting ~w relation: ~w\n',[R,F]),
+  catch(consult(F), Err, format('ERROR: ~w\n', [Err])),
   false.
 loadrels:-
   nl.
 
-:-loadrels.
 
 /* ------------------------------------------------------------------
 Synonyms have the same identifier: */
@@ -37,7 +37,7 @@ thyp(A,C):-
   hyp(A,B),
   thyp(B,C),
 % Prevent transitive loops (f. ex. in original WordNet 3.0):
- (A=C, !, writef('Transitive loop: %w %w %w\n', [A,B,C]); true).
+ (A=C, !, format('Transitive loop: ~w ~w ~w\n', [A,B,C]); true).
 
 /* ------------------------------------------------------------------
 Word relations
@@ -46,20 +46,21 @@ Word relations
 wordrel(R,A,B):-
 % R is a relation between synsets, A and B are words
   s(I,_,A,_,_,_),
-  apply(R,[I,J]),
+  call(R,I,J),
   s(J,_,B,_,_,_).
 
 out2set([],_,_,[]).
 out2set([H|T],W,R,S):-
   sort([H|T],S),
   outset(S,'',O),
-  writef('%w %w: [%w]\n',[W,R,O]).
+  format('~w ~w: [~w]\n',[W,R,O]).
 
 outset([H],A,B):-
-  swritef(B,'%w%w', [A,H]).
+  atom_concat(A,H,B).
 outset([H|T],A,C):-
-  swritef(B,'%w%w,', [A,H]),
-  outset(T,B,C).
+  atom_concat(A,H,B0),
+  atom_concat(B0, ',', B),
+  outset(T,B,C). % format('outset(~q,~q-> ~q)\n',[A,[H|T],C]).
 
 sameset([H|T],[H|T]).
 
@@ -70,11 +71,11 @@ irel(R,W):-
   out2set(L1,W,R,S1),
 % 2) Inverse relation
   findall(Y, wordrel(R,Y,W), L2),
-  swritef(Ri,'inverse %w',[R]),
+  atom_concat('inverse ', R, Ri),
   out2set(L2,W,Ri,S2),
 % 3) Check if R is symmetric
 % If both sets are identical and non-empty, the relation is symmetric w.r.t. the query word:
-  (sameset(S1,S2) -> writef('Both sets are identical, so %w(%w,X) is symmetric\n', [R,W]); true).
+  (sameset(S1,S2) -> format('Both sets are identical, so ~w(~w,X) is symmetric\n', [R,W]); true).
 
 /* ------------------------------------------
 Word query
@@ -95,6 +96,7 @@ Test some word queries
 ------------------------------------------ */
 
 go:-
+  loadrels,
   wn_version(WV),
   atom_concat('output/wn_query.pl-Output-',WV,F),
   tell(F),
@@ -104,4 +106,5 @@ go:-
   false.
 go:-
   told.
-:-go.
+
+:- initialization(go).

--- a/wn_term_expans.pl
+++ b/wn_term_expans.pl
@@ -1,0 +1,32 @@
+/* 
+# https://github.com/ekaf/wordnet-prolog/raw/master/wn_valid.pl
+(c) 2020-24 Eric Kafe, CC BY 4.0, https://creativecommons.org/licenses/by/4.0/
+
+Definiton of term_expansion/2 to speed up wn_valid.pl
+*/
+
+/*
+See comment in wn_valid.pl.
+
+This term_expansion tenchnique has been proposed by Markus Triska Scryer Prolog.
+See https://github.com/mthom/scryer-prolog/issues/1681#issuecomment-1374852413 %
+and https://github.com/mthom/scryer-prolog/issues/1681#issuecomment-1374853910.
+
+It also works for other prolog systems only indexing predicates on the
+first-argument (it is adapted for gprolog too).
+*/
+
+:- discontiguous(sk_1/3).
+:- discontiguous(sk_3/3).
+
+term_expansion(sk(X,Y,Z),
+               [sk_1(X,Y,Z),
+                sk_3(Z,X,Y)]).
+
+sk(X, Y, Z) :-
+        (   nonvar(X) ->
+            sk_1(X, Y, Z)
+        ;   nonvar(Z) ->
+            sk_3(Z, X, Y)
+        ;   sk_1(X, Y, Z)
+        ).

--- a/wn_valid.pl
+++ b/wn_valid.pl
@@ -11,8 +11,11 @@ SWI-prolog program testing for some potential issues in WordNet:
 - check_duplicates: find duplicate clauses
 */
 
+:- include(wn_compat).
+:- include(db_version).
+
 ok:-
-  writeln('OK').
+  write('OK'), nl.
 
 glosspair(A,B,G1,G2):-
   g(A,G1),
@@ -22,26 +25,69 @@ glosspair(A,B,G1,G2):-
 Ambiguous sense keys
 ------------------------------------------ */
 
-multikey(K):-
-  sk(I,_,K),
-  sk(J,_,K),
-  I\=J.
-
 check_keys:-
-  writeln('Searching for ambiguous sense keys'),
-  findall(X, multikey(X), L),
-  list_to_set(L,S),
-  member(K,S),
-  writef("Ambiguous key: %w\n",[K]),
-  findall(I, sk(I,_,K), IL),
-  list_to_set(IL,IS),
+  write('Searching for ambiguous sense keys'), nl,
+  find_multikey(K, IS),
+  format('Ambiguous key: ~w\n',[K]),
   member(I,IS),
   g(I,G),
-  writef("    ->%w (%w)\n",[I,G]),
+  format('    ->~w (~w)\n',[I,G]),
   false.
 check_keys:-
   ok,
   nl.
+
+/* :- if(true) for the original implementation of check_keys/0 based on original multikey/1.
+   It needs an indexing mechanism on the third argument of sk/3 to obtain good performance.
+   SWI performs well thanks to its multi-argument indexing.
+   Prolog systems only indexing the first argument perform poorly.
+
+   Markus Triska proposed a solution based on term_expansion/2 to index sk/3.
+   See https://github.com/mthom/scryer-prolog/issues/1681#issuecomment-1374852413
+   We use this approach  (see file wn_term_expans.pl)
+   
+   :- if(false) for an alternative implementation of checkeys/0 based on a new multikey/2.
+   Daniel Diaz proposed another solution based on findall/setof and keysort
+   (which are generally efficiently implemented).
+   See https://github.com/mthom/scryer-prolog/issues/1681#issuecomment-1602996049
+
+   If keeping both, consider factorizing similar code of both implementations.
+*/
+
+:- if(true).	% Original implementation with term_expansion/2 for other systems than SWI
+
+:- if(current_prolog_flag(dialect, gprolog)).
+:- compiler_mode(embed_compile).
+:- endif.
+
+use_term_expansion. % this is tested in wn_load.pl
+
+:- if(current_prolog_flag(dialect, gprolog)).
+:- compiler_mode(default).
+:- endif.
+
+find_multikey(K, IS) :-
+  findall(X, multikey(X), L),
+  list_to_set(L,S),
+  member(K,S),
+  findall(I, sk(I,_,K), IL),
+  list_to_set(IL,IS).
+
+multikey(K):-
+  sk(I,_,K),
+  sk(J,_,K),
+  I \== J.
+
+:- else.	% Alternative implementation based on findall/setof and keysort
+
+find_multikey(K, IL) :-
+  findall(K-I, sk(I, _, K), L1),
+  keysort(L1, L2),
+  setof(I, member(K-I, L2), IL),
+  length(IL, N),
+  N > 1.  % ensure at least 2 different tuples I \== J
+
+:- endif.
 
 /* ------------------------------------------
 Symmetry Test
@@ -50,24 +96,23 @@ Symmetry Test
 symrels(['sim','ant','der','vgp']).
 
 symrel(2,R):-
-  apply(R,[A,B]),
-  (apply(R,[B,A]) -> true; writef('Missing %w(%w,%w)\n',[R,B,A])),
+  call(R,A,B),
+  (call(R,B,A) -> true; format('Missing ~w(~w,~w)\n',[R,B,A])),
   false.
 symrel(4,R):-
-  apply(R,[A,B,C,D]),
+  call(R,A,B,C,D),
   sk(A,B,K1),
-  (apply(R,[C,D,A,B]) -> true; (sk(C,D,K2), writef('Missing %w from %w to %w\n',[R,K2,K1]))),
+  (call(R,C,D,A,B) -> true; (sk(C,D,K2), format('Missing ~w from ~w to ~w\n',[R,K2,K1]))),
   false.
 symrel(_,_):-
   ok.
 
 symcheck:-
   symrels(L),
-  writef('Symmetric relations: %w\n',[L]),
+  format('Symmetric relations: ~w\n',[L]),
   member(R,L),
-  swritef(F,'wn_%w.pl',[R]),
-  writef('Checking symmetry in %w relation (%w):\n',[R,F]),
-  pred2arity(R,N,_),
+  format('Checking symmetry in ~w relation (wn_~w.pl):\n',[R,R]),
+  pred2arity(R,N),
   symrel(N,R),
   false.
 symcheck:-
@@ -83,24 +128,23 @@ asymrel(cls):-
   cls(A,AN,B,BN,T),
   cls(B,BN,A,AN,T),
   glosspair(A,B,G1,G2),
-  writef('Looping cls-%w:\n  from %w-%w (%w)\n    to %w-%w (%w)\n',[T,A,AN,G1,B,BN,G2]),
+  format('Looping cls-~w:\n  from ~w-~w (~w)\n    to ~w-~w (~w)\n',[T,A,AN,G1,B,BN,G2]),
   false.
 asymrel(R):-
   R\=cls,
-  apply(R,[A,B]),
-  apply(R,[B,A]),
+  call(R,A,B),
+  call(R,B,A),
   glosspair(A,B,G1,G2),
-  writef('Looping %w:\n  from %w (%w)\n    to %w (%w)\n',[R,A,G1,B,G2]),
+  format('Looping ~w:\n  from ~w (~w)\n    to ~w (~w)\n',[R,A,G1,B,G2]),
   false.
 asymrel(_):-
   ok.
 
 asymcheck:-
   asymrels(L),
-  writef('Asymmetric relations: %w\n',[L]),
+  format('Asymmetric relations: ~w\n',[L]),
   member(R,L),
-  swritef(F,'wn_%w.pl',[R]),
-  writef('Checking asymmetry in %w relation (%w):\n',[R,F]),
+  format('Checking asymmetry in ~w relation (wn_~w.pl):\n',[R,R]),
   asymrel(R),
   false.
 asymcheck:-
@@ -118,7 +162,7 @@ hypself:-
   s(A,N1,W,_,_,_),
   s(B,N2,W,_,_,_),
   glosspair(A,B,G1,G2),
-  writef('"%w" hyp:\n  from %w-%w (%w)\n    to %w-%w (%w)\n',[W,A,N1,G1,B,N2,G2]),
+  format('"~w" hyp:\n  from ~w-~w (~w)\n    to ~w-~w (~w)\n',[W,A,N1,G1,B,N2,G2]),
   false.
 hypself:-
   ok,
@@ -129,18 +173,21 @@ Find Duplicates
 ------------------------------------------ */
 
 
-:-dynamic duplicate/3.
+:- dynamic(duplicate/3).
 
 outdups(N,P):-
-  writef('Found %w duplicate %w:\n',[N,P]),
-  listing(duplicate),
-  retractall(duplicate(_,_,_)).
+  format('Found ~w duplicate ~w:\n',[N,P]),
+  retract(duplicate(X,Y,Z)),
+  format('duplicate(~w, ~w, ~w).~n', [X, Y, Z]),
+  fail.
+outdups(_,_).
+
 
 check_dup(P,L):-
   apply(P,L),
   findall((P,L), apply(P,L), PL),
   length(PL,N),
-  (N>1, \+ duplicate(N,P,L) -> assert(duplicate(N,P,L))),
+  (N>1, \+ duplicate(N,P,L) -> assertz(duplicate(N,P,L))),
   false.
 check_dup(P,_):-
   findall((A,B,C),duplicate(A,B,C),L),
@@ -151,7 +198,7 @@ check_duplicates:-
   allwn(LR),
   member(P,LR),
   pred2arity(P,A,L),
-  writef('Checking duplicates in %w/%w\n',[P,A]),
+  format('Checking duplicates in ~w/~w\n',[P,A]),
   check_dup(P,L),
   false.
 check_duplicates:-
@@ -162,15 +209,18 @@ WN Validation
 ------------------------------------------ */
 
 valid:-
-  consult('db_version.pl'),
   wn_version(WV),
   atom_concat('output/wn_valid.pl-Output-',WV,F),
   tell(F),
-  consult('wn_load.pl'),
+  loadwn,
   check_keys,
   symcheck,
   asymcheck,
   check_duplicates,
 %  hypself,
   told.
-:-valid.
+
+:- include(wn_load). % this include must occur after use_term_expansion definition
+
+:- initialization(valid).
+


### PR DESCRIPTION
Decouple the system from SWI and enable other Prolog engines such as GProlog and Trealla (tpl).

Changes:
- Use write/1 + nl/0 (ISO) instead of writeln/1 (SWI).
- Use format/2 (standard) instead of writef/2 and some swritef/2 (SWI).
- Use atom_concat/3 (ISO) instead of some swritef/2 (SWI).
- Use the :- initialization(Goal) directive (ISO) instead of :- Goal (SWI).
- Use call/2-n (ISO) instead of apply/2 (SWI) when possible.
- Use current_predicate/1 (ISO) instead of current_predicate/2 (SWI) for pred2arity/3. Add new specialized add pred2arity/2 when the arg list is not needed.
- Provide a new file wn_compat.pl for system-specific code.
- Update Makefile for SWI to execute swipl -g halt prolog_program.pl instead of swipl -c (which creates an executable a.out not used).
- Redesign Makefile to accept other Prolog systems (needs GNU make). Usage: make or make PL=swi/gprolog/tpl (default=swi) It should be easy to support other Prolog systems (scryer, ciao, ...).