### PR TITLE
Add GitHub Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,94 +18,41 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get branch name for tagged commit
+      - name: Get branch name
         id: branch
         run: |
-          # Get the commit hash of the tag
-          COMMIT_HASH=$(git rev-list -n 1 ${{ github.ref }})
-          
-          # Find all branches containing this commit
-          BRANCH=$(git branch -r --contains $COMMIT_HASH | grep -v HEAD | head -1 | sed 's/^[[:space:]]*origin\///')
-          
-          if [ -z "$BRANCH" ]; then
-            BRANCH="unknown"
-          fi
-          
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "Branch: $BRANCH"
+          BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's/^[[:space:]]*origin\///')
+          echo "branch=${BRANCH:-unknown}" >> $GITHUB_OUTPUT
 
-      - name: Generate release notes from merged PRs
-        id: release_notes
+      - name: Generate release notes
+        id: notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Extract version from tag
-          TAG=${{ github.ref }}
-          VERSION=${TAG#refs/tags/}
+          VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           
-          # Get the previous tag
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 ${TAG}^ 2>/dev/null || echo "")
+          PREV_TAG=$(git describe --tags --abbrev=0 ${GITHUB_REF}^ 2>/dev/null || echo "")
           
-          if [ -z "$PREVIOUS_TAG" ]; then
-            # If no previous tag, use all merged PRs
-            CHANGELOG=$(gh pr list --state merged --limit 500 --json title --jq '.[] | "- " + .title' | head -50)
-          else
-            # Get commits between tags and find associated merged PRs
-            COMMITS=$(git log ${PREVIOUS_TAG}..${TAG} --pretty=format:"%B" | grep -oP '#\d+' | sort -u)
-            
-            CHANGELOG=""
-            for pr_num in $COMMITS; do
-              PR_TITLE=$(gh pr view ${pr_num#\#} --json title --jq '.title' 2>/dev/null)
-              if [ -n "$PR_TITLE" ]; then
-                CHANGELOG="${CHANGELOG}$(echo "- $PR_TITLE")\n"
-              fi
-            done
-            
-            if [ -z "$CHANGELOG" ]; then
-              CHANGELOG="No merged PRs found since last release."
-            fi
+          if [ -n "$PREV_TAG" ]; then
+            CHANGELOG=$(git log ${PREV_TAG}..${GITHUB_REF} --pretty=format:"%B" | grep -oP '#\d+' | sort -u | while read pr; do
+              gh pr view ${pr#\#} --json title --jq '.title' 2>/dev/null
+            done | sed 's/^/- /')
           fi
           
-          # Store changelog in output variable
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "${CHANGELOG:-No changes}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Build release package
-        id: build
-        run: |
-          VERSION=${{ steps.release_notes.outputs.version }}
-          BRANCH=${{ steps.branch.outputs.branch }}
-          PACKAGE_NAME="wordnet-prolog-${BRANCH}-${VERSION}"
-          
-          # Create package directory
-          mkdir -p "${PACKAGE_NAME}"
-          
-          # Copy source files (customize as needed for your project)
-          cp -r wn_*.pl "${PACKAGE_NAME}/" 2>/dev/null || true
-          cp -r *.pl "${PACKAGE_NAME}/" 2>/dev/null || true
-          cp README.md LICENSE* NOTICE "${PACKAGE_NAME}/" 2>/dev/null || true
-          cp Makefile "${PACKAGE_NAME}/" 2>/dev/null || true
-          
-          # Create compressed archive
-          tar -czf "${PACKAGE_NAME}.tar.gz" "${PACKAGE_NAME}"
-          
-          echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
-          echo "Package created: ${PACKAGE_NAME}.tar.gz"
-
-      - name: Create GitHub Release
+      - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.release_notes.outputs.version }}
-          name: "${{ steps.branch.outputs.branch }}-${{ steps.release_notes.outputs.version }}"
+          tag_name: ${{ steps.notes.outputs.version }}
+          name: "${{ steps.branch.outputs.branch }}-${{ steps.notes.outputs.version }}"
           body: |
-            ## Changes in ${{ steps.release_notes.outputs.version }}
+            ## Changes
             
-            ${{ steps.release_notes.outputs.changelog }}
-          files: |
-            ${{ steps.build.outputs.package_name }}.tar.gz
+            ${{ steps.notes.outputs.changelog }}
           draft: false
-          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - run: |
           cd /tmp
           tar -czf ${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz -C ${{ github.workspace }} --exclude=.git --exclude=.github .
-          zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip -x '.git/*' '.github/*' ${{ github.workspace }}
+          zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip ${{ github.workspace }} -x '${{ github.workspace }}/.git/*' '${{ github.workspace }}/.github/*'
           mv ${{ steps.b.outputs.n }}-${{ github.ref_name }}.* ${{ github.workspace }}/
 
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,90 +10,31 @@ env:
 
 permissions:
   contents: write
-  pull-requests: read
 
 jobs:
-  create-release:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get branch name from tag
-        id: branch
-        run: |
-          BRANCHES=$(git branch -r --contains ${{ github.ref }} | sed 's/^[[:space:]]*origin\///' | grep -v HEAD)
-          BRANCH_COUNT=$(echo "$BRANCHES" | wc -l)
-          
-          if [ $BRANCH_COUNT -eq 1 ]; then
-            BRANCH=$(echo "$BRANCHES" | head -1)
-          else
-            BRANCH=$(echo "$BRANCHES" | grep -v -E '^(main|master)$' | head -1)
-            if [ -z "$BRANCH" ]; then
-              echo "::error::Tag exists on multiple branches ($BRANCHES). Please create a branch-specific tag."
-              exit 1
-            fi
-          fi
-          
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "::notice::Release branch: $BRANCH"
+      - id: b
+        run: echo "n=$(git branch -r --contains HEAD | sed 's/.*\///' | grep -v HEAD | head -1)" >> $GITHUB_OUTPUT
 
-      - name: Generate release notes
-        id: notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
-          PREV_TAG=$(git describe --tags --abbrev=0 ${GITHUB_REF}^ 2>/dev/null || echo "")
-          
-          if [ -n "$PREV_TAG" ]; then
-            LOG_RANGE="${PREV_TAG}..${GITHUB_REF}"
-            EMPTY_MSG="No changes"
-          else
-            LOG_RANGE="${GITHUB_REF}"
-            EMPTY_MSG="First release - no pull requests found in commit history"
-          fi
-          
-          CHANGELOG=$(git log ${LOG_RANGE} --pretty=format:"%B" | grep -Eo '#[0-9]+' | sort -u | while read -r pr; do
-            gh pr view ${pr#\#} --json title --jq '.title' 2>/dev/null
-          done | sed 's/^/- /')
-          
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "${CHANGELOG:-$EMPTY_MSG}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      - run: |
+          cd /tmp
+          tar -czf ${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz -C ${{ github.workspace }} --exclude=.git --exclude=.github .
+          zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip ${{ github.workspace }} -x '.git/*' '.github/*'
+          mv ${{ steps.b.outputs.n }}-${{ github.ref_name }}.* ${{ github.workspace }}/
 
-      - name: Create release packages
-        env:
-          BRANCH: ${{ steps.branch.outputs.branch }}
-          VERSION: ${{ steps.notes.outputs.version }}
-        run: |
-          PACKAGE_NAME="${BRANCH}-${VERSION}"
-          tar -czf "${PACKAGE_NAME}.tar.gz" \
-            --exclude='.git' \
-            --exclude='.github' \
-            --exclude='*.tar.gz' \
-            --exclude='*.zip' \
-            .
-          zip -r -q "${PACKAGE_NAME}.zip" . \
-            -x '.git/*' '.github/*' '*.tar.gz' '*.zip'
-          echo "packages=${PACKAGE_NAME}" >> $GITHUB_ENV
-
-      - name: Create release
-        uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.notes.outputs.version }}
-          name: "${{ steps.branch.outputs.branch }}-${{ steps.notes.outputs.version }}"
-          body: |
-            ## Changes
-            
-            ${{ steps.notes.outputs.changelog }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ steps.b.outputs.n }}-${{ github.ref_name }}
+          generate_release_notes: true
           files: |
-            ${{ env.packages }}.tar.gz
-            ${{ env.packages }}.zip
-          draft: false
+            ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz
+            ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,14 @@ jobs:
           VERSION: ${{ steps.notes.outputs.version }}
         run: |
           PACKAGE_NAME="${BRANCH}-${VERSION}"
-          tar -czf "${PACKAGE_NAME}.tar.gz" --exclude='.git' --exclude='.github' .
-          zip -r -q "${PACKAGE_NAME}.zip" . -x '.git/*' '.github/*'
+          tar -czf "${PACKAGE_NAME}.tar.gz" \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='*.tar.gz' \
+            --exclude='*.zip' \
+            .
+          zip -r -q "${PACKAGE_NAME}.zip" . \
+            -x '.git/*' '.github/*' '*.tar.gz' '*.zip'
           echo "packages=${PACKAGE_NAME}" >> $GITHUB_ENV
 
       - name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,12 @@ jobs:
       - name: Get branch name from tag
         id: branch
         run: |
-          # Get all branches containing this tag
           BRANCHES=$(git branch -r --contains ${{ github.ref }} | sed 's/^[[:space:]]*origin\///' | grep -v HEAD)
-          
-          # Count branches and handle accordingly
           BRANCH_COUNT=$(echo "$BRANCHES" | wc -l)
           
           if [ $BRANCH_COUNT -eq 1 ]; then
-            # Only one branch, use it
             BRANCH=$(echo "$BRANCHES" | head -1)
           else
-            # Multiple branches: use the first non-main/master branch, or prompt user
             BRANCH=$(echo "$BRANCHES" | grep -v -E '^(main|master)$' | head -1)
             if [ -z "$BRANCH" ]; then
               echo "::error::Tag exists on multiple branches ($BRANCHES). Please create a branch-specific tag."
@@ -71,6 +66,16 @@ jobs:
           echo "${CHANGELOG:-$EMPTY_MSG}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Create release packages
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ steps.notes.outputs.version }}
+        run: |
+          PACKAGE_NAME="${BRANCH}-${VERSION}"
+          tar -czf "${PACKAGE_NAME}.tar.gz" --exclude='.git' --exclude='.github' .
+          zip -r -q "${PACKAGE_NAME}.zip" . -x '.git/*' '.github/*'
+          echo "packages=${PACKAGE_NAME}" >> $GITHUB_ENV
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
@@ -80,6 +85,9 @@ jobs:
             ## Changes
             
             ${{ steps.notes.outputs.changelog }}
+          files: |
+            ${{ env.packages }}.tar.gz
+            ${{ env.packages }}.zip
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
       - run: |
           cd /tmp
           tar -czf ${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz -C ${{ github.workspace }} --exclude=.git --exclude=.github .
-          zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip ${{ github.workspace }} -x '${{ github.workspace }}/.git/*' '${{ github.workspace }}/.github/*'
-          mv -- ${{ steps.b.outputs.n }}-${{ github.ref_name }}.* ${{ github.workspace }}/
+          cd ${{ github.workspace }}
+          zip -r -q /tmp/${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip . -x '.git/*' '.github/*'
+          mv -- /tmp/${{ steps.b.outputs.n }}-${{ github.ref_name }}.* .
 
       - uses: softprops/action-gh-release@v1
         with:
@@ -39,5 +40,6 @@ jobs:
             ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz
             ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip
           draft: false
+          make_latest: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   pull-requests: read
@@ -18,11 +21,29 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get branch name
+      - name: Get branch name from tag
         id: branch
         run: |
-          BRANCH=$(git branch -r --contains HEAD | grep -v HEAD | head -1 | sed 's/^[[:space:]]*origin\///')
-          echo "branch=${BRANCH:-unknown}" >> $GITHUB_OUTPUT
+          # Get all branches containing this tag
+          BRANCHES=$(git branch -r --contains ${{ github.ref }} | sed 's/^[[:space:]]*origin\///' | grep -v HEAD)
+          
+          # Count branches and handle accordingly
+          BRANCH_COUNT=$(echo "$BRANCHES" | wc -l)
+          
+          if [ $BRANCH_COUNT -eq 1 ]; then
+            # Only one branch, use it
+            BRANCH=$(echo "$BRANCHES" | head -1)
+          else
+            # Multiple branches: use the first non-main/master branch, or prompt user
+            BRANCH=$(echo "$BRANCHES" | grep -v -E '^(main|master)$' | head -1)
+            if [ -z "$BRANCH" ]; then
+              echo "::error::Tag exists on multiple branches ($BRANCHES). Please create a branch-specific tag."
+              exit 1
+            fi
+          fi
+          
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "::notice::Release branch: $BRANCH"
 
       - name: Generate release notes
         id: notes
@@ -35,13 +56,19 @@ jobs:
           PREV_TAG=$(git describe --tags --abbrev=0 ${GITHUB_REF}^ 2>/dev/null || echo "")
           
           if [ -n "$PREV_TAG" ]; then
-            CHANGELOG=$(git log ${PREV_TAG}..${GITHUB_REF} --pretty=format:"%B" | grep -oP '#\d+' | sort -u | while read pr; do
-              gh pr view ${pr#\#} --json title --jq '.title' 2>/dev/null
-            done | sed 's/^/- /')
+            LOG_RANGE="${PREV_TAG}..${GITHUB_REF}"
+            EMPTY_MSG="No changes"
+          else
+            LOG_RANGE="${GITHUB_REF}"
+            EMPTY_MSG="First release - no pull requests found in commit history"
           fi
           
+          CHANGELOG=$(git log ${LOG_RANGE} --pretty=format:"%B" | grep -Eo '#[0-9]+' | sort -u | while read -r pr; do
+            gh pr view ${pr#\#} --json title --jq '.title' 2>/dev/null
+          done | sed 's/^/- /')
+          
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "${CHANGELOG:-No changes}" >> $GITHUB_OUTPUT
+          echo "${CHANGELOG:-$EMPTY_MSG}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get branch name for tagged commit
+        id: branch
+        run: |
+          # Get the commit hash of the tag
+          COMMIT_HASH=$(git rev-list -n 1 ${{ github.ref }})
+          
+          # Find all branches containing this commit
+          BRANCH=$(git branch -r --contains $COMMIT_HASH | grep -v HEAD | head -1 | sed 's/^[[:space:]]*origin\///')
+          
+          if [ -z "$BRANCH" ]; then
+            BRANCH="unknown"
+          fi
+          
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "Branch: $BRANCH"
+
+      - name: Generate release notes from merged PRs
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extract version from tag
+          TAG=${{ github.ref }}
+          VERSION=${TAG#refs/tags/}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
+          # Get the previous tag
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 ${TAG}^ 2>/dev/null || echo "")
+          
+          if [ -z "$PREVIOUS_TAG" ]; then
+            # If no previous tag, use all merged PRs
+            CHANGELOG=$(gh pr list --state merged --limit 500 --json title --jq '.[] | "- " + .title' | head -50)
+          else
+            # Get commits between tags and find associated merged PRs
+            COMMITS=$(git log ${PREVIOUS_TAG}..${TAG} --pretty=format:"%B" | grep -oP '#\d+' | sort -u)
+            
+            CHANGELOG=""
+            for pr_num in $COMMITS; do
+              PR_TITLE=$(gh pr view ${pr_num#\#} --json title --jq '.title' 2>/dev/null)
+              if [ -n "$PR_TITLE" ]; then
+                CHANGELOG="${CHANGELOG}$(echo "- $PR_TITLE")\n"
+              fi
+            done
+            
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG="No merged PRs found since last release."
+            fi
+          fi
+          
+          # Store changelog in output variable
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Build release package
+        id: build
+        run: |
+          VERSION=${{ steps.release_notes.outputs.version }}
+          BRANCH=${{ steps.branch.outputs.branch }}
+          PACKAGE_NAME="wordnet-prolog-${BRANCH}-${VERSION}"
+          
+          # Create package directory
+          mkdir -p "${PACKAGE_NAME}"
+          
+          # Copy source files (customize as needed for your project)
+          cp -r wn_*.pl "${PACKAGE_NAME}/" 2>/dev/null || true
+          cp -r *.pl "${PACKAGE_NAME}/" 2>/dev/null || true
+          cp README.md LICENSE* NOTICE "${PACKAGE_NAME}/" 2>/dev/null || true
+          cp Makefile "${PACKAGE_NAME}/" 2>/dev/null || true
+          
+          # Create compressed archive
+          tar -czf "${PACKAGE_NAME}.tar.gz" "${PACKAGE_NAME}"
+          
+          echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "Package created: ${PACKAGE_NAME}.tar.gz"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.release_notes.outputs.version }}
+          name: "${{ steps.branch.outputs.branch }}-${{ steps.release_notes.outputs.version }}"
+          body: |
+            ## Changes in ${{ steps.release_notes.outputs.version }}
+            
+            ${{ steps.release_notes.outputs.changelog }}
+          files: |
+            ${{ steps.build.outputs.package_name }}.tar.gz
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: GitHub Release
 on:
   push:
     tags:
-      - "v*"
+      - "*-v*" # Updated to catch tags like 'WNprolog-3.1-v1.0.0'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -16,29 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
+      - uses: softprops/action-gh-release@v3
         with:
-          fetch-depth: 0
-
-      - id: b
-        run: |
-          BRANCH=$(git branch -r --contains HEAD | sed 's/.*\///' | grep -v HEAD | head -1)
-          echo "n=${BRANCH:-${{ github.event.repository.default_branch }}}" >> $GITHUB_OUTPUT
-
-      - run: |
-          cd /tmp
-          tar -czf ${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz -C ${{ github.workspace }} --exclude=.git --exclude=.github .
-          cd ${{ github.workspace }}
-          zip -r -q /tmp/${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip . -x '.git/*' '.github/*'
-          mv -- /tmp/${{ steps.b.outputs.n }}-${{ github.ref_name }}.* .
-
-      - uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ steps.b.outputs.n }}-${{ github.ref_name }}
           generate_release_notes: true
-          files: |
-            ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz
-            ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip
           draft: false
           make_latest: false
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - run: |
           cd /tmp
           tar -czf ${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz -C ${{ github.workspace }} --exclude=.git --exclude=.github .
-          zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip ${{ github.workspace }} -x '.git/*' '.github/*'
+          zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip -x '.git/*' '.github/*' ${{ github.workspace }}
           mv ${{ steps.b.outputs.n }}-${{ github.ref_name }}.* ${{ github.workspace }}/
 
       - uses: softprops/action-gh-release@v1
@@ -36,5 +36,6 @@ jobs:
           files: |
             ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz
             ${{ github.workspace }}/${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip
+          draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,15 @@ jobs:
           fetch-depth: 0
 
       - id: b
-        run: echo "n=$(git branch -r --contains HEAD | sed 's/.*\///' | grep -v HEAD | head -1)" >> $GITHUB_OUTPUT
+        run: |
+          BRANCH=$(git branch -r --contains HEAD | sed 's/.*\///' | grep -v HEAD | head -1)
+          echo "n=${BRANCH:-${{ github.event.repository.default_branch }}}" >> $GITHUB_OUTPUT
 
       - run: |
           cd /tmp
           tar -czf ${{ steps.b.outputs.n }}-${{ github.ref_name }}.tar.gz -C ${{ github.workspace }} --exclude=.git --exclude=.github .
           zip -r -q ${{ steps.b.outputs.n }}-${{ github.ref_name }}.zip ${{ github.workspace }} -x '${{ github.workspace }}/.git/*' '${{ github.workspace }}/.github/*'
-          mv ${{ steps.b.outputs.n }}-${{ github.ref_name }}.* ${{ github.workspace }}/
+          mv -- ${{ steps.b.outputs.n }}-${{ github.ref_name }}.* ${{ github.workspace }}/
 
       - uses: softprops/action-gh-release@v1
         with:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Type "make valid" or "make query" to run the Prolog programs,
 or "make csv" to generate CSV databases.
 
 
-## News (2020):
+## ChangeLog
+
+### 2020
 
 CSV versions of the WordNet databases (output by _wn2csv.pl_) are now
 available through the _wncsv_ project at:
@@ -100,7 +102,7 @@ available through the _wncsv_ project at:
 https://github.com/ekaf/wncsv
 
 
-## News (2025):
+### 2025
 
 - Added utils.pl: system-independent implementations of non-standard predicates.
 - Added timeit.pl to time predicate calls.
@@ -128,10 +130,14 @@ Or specify PL=gprolog to use gprolog instead of the default:
 make valid PL=gprolog
 
 
-## News (2026):
+### 2026
 
-- Speed up the transitive relation closures, for ex. [_thyp_ in wn_query](wn_query.pl).
+- Transitive relation closures in linear time
 - Use no hard cut.
 - Use call/N instead of univ (=..).
 - Add loader.pl, to load files only once.
 - Quote strings and fix quotes in CSV output.
+- Add SPDX license and copyright tags
+- Portable output predicates
+- Portability validation workflow
+- Release workflow


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow that automates release creation when version tags are pushed.

**Features:**
- Automatically triggers when pushing a tag containing `-v` (e.g., `anything-v1.0.0`)
- Generates release notes from merged PR titles since the previous release
- Release title equals the tag name
- Builds and uploads a compressed release package containing source files and documentation

**Usage:**
```bash
git tag pwn-v1.0.0
git push origin pwn-v1.0.0